### PR TITLE
Update default rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ Style/WordArray: { EnforcedStyle: brackets }
 ################################################################################
 
 Bundler/GemComment: { Enabled: false }
+Rails/RakeEnvironment: { Enabled: false }
 RSpec/AlignLeftLetBrace: { Enabled: false }
 RSpec/AlignRightLetBrace: { Enabled: false }
 Style/ConstantVisibility: { Enabled: false }

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,39 @@
 
 require_relative "config/application"
 
-Rails.application.load_tasks
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
 
-require "bundler/audit/task"
-Bundler::Audit::Task.new
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+
+  require "haml_lint/rake_task"
+  HamlLint::RakeTask.new
+
+  task("yarn:audit") do
+    sh("yarn audit")
+  end
+
+  task(:brakeman) do
+    sh("bundle exec brakeman")
+  end
+
+  task(:stylelint) do
+    sh("yarn stylelint")
+  end
+
+  task(lint: [
+         "yarn:install",
+         "yarn:audit",
+         "bundle:audit",
+         :brakeman,
+         :rubocop,
+         :haml_lint,
+         :stylelint,
+       ])
+
+  task(default: [:lint, :spec])
+end
+
+Rails.application.load_tasks


### PR DESCRIPTION
This makes it so that we can run `rake` lint to run all lints and `rake`
and run *all* lints and tests. This should make it easier for local
development to run a quick pass before pull requesting changes.