### PR TITLE
Only allow admins to create questions/answers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Style/MethodCallWithArgsParentheses:
     - default
     - delegate
     - describe
+    - enum
     - exec
     - exit
     - fit

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.6.3"
 
 gem "rails", "~> 6.0.0"
 
+gem "activerecord-pg_enum"
 gem "bcrypt"
 gem "bootsnap", require: false
 gem "haml-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,10 @@ GEM
     activerecord (6.0.2.1)
       activemodel (= 6.0.2.1)
       activesupport (= 6.0.2.1)
+    activerecord-pg_enum (1.0.5)
+      activerecord (>= 4.1.0)
+      activesupport
+      pg
     activestorage (6.0.2.1)
       actionpack (= 6.0.2.1)
       activejob (= 6.0.2.1)
@@ -342,6 +346,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-pg_enum
   bcrypt
   bootsnap
   brakeman

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   has_secure_password
 
+  enum role: { admin: "admin", viewer: "viewer" }
+
   has_many :questions, dependent: :restrict_with_exception
   has_many :answers, dependent: :restrict_with_exception
 
@@ -18,9 +20,5 @@ class User < ApplicationRecord
 
   def logged_in?
     true
-  end
-
-  def admin?
-    false
   end
 end

--- a/app/views/answers/new.html.haml
+++ b/app/views/answers/new.html.haml
@@ -3,4 +3,4 @@
 = form_with(scope: :answer, url: question_answers_path(question)) do |form|
   = form.label(:text)
   = form.text_field(:text)
-  = form.submit("Create Answer")
+  = form.submit(t("create_answer"))

--- a/app/views/questions/new.html.haml
+++ b/app/views/questions/new.html.haml
@@ -1,4 +1,4 @@
 = form_with(scope: :question, url: questions_path) do |form|
   = form.label(:text)
   = form.text_field(:text)
-  = form.submit("Create Question")
+  = form.submit(t("create_question"))

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,8 +1,8 @@
 Welcome
-= link_to("Add question", new_question_path)
+= link_to(t("add_question"), new_question_path) if current_user.admin?
 - questions.each do |question|
   %h3= question.text
   - if question.answer
     %p= question.answer.text
-  - else
-    = link_to("Add answer", new_question_answer_path(question))
+  - elsif current_user.admin?
+    = link_to(t("add_answer"), new_question_answer_path(question))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  add_answer: Add answer
+  add_question: Add question
+  create_answer: Create Answer
+  create_question: Create Question

--- a/db/migrate/20191220221449_add_role_to_users.rb
+++ b/db/migrate/20191220221449_add_role_to_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      create_enum :role_type, ["viewer", "admin"]
+      change_table :users do |t|
+        t.enum :role, as: "role_type", default: "viewer", null: false
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_15_224837) do
+ActiveRecord::Schema.define(version: 2019_12_20_221449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  # These are custom enum types that must be created before they can be used in the schema definition
+  create_enum "role_type", ["viewer", "admin"]
 
   create_table "answers", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -41,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_12_15_224837) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.enum "role", default: "viewer", null: false, as: "role_type"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,12 +1,28 @@
 # frozen_string_literal: true
 
 module SystemHelpers
+  def t(key)
+    I18n.t(key)
+  end
+
   def user_params
     {
       email: "demo@lmkw.io",
       password: "secret",
       password_confirmation: "secret",
     }
+  end
+
+  def create_question(params)
+    Question.create!(params)
+
+    visit(current_path)
+  end
+
+  def create_and_sign_in_admin
+    user = User.create!(user_params.merge(role: :admin))
+    sign_in_as(user)
+    user
   end
 
   def create_and_sign_in_user
@@ -29,14 +45,15 @@ module SystemHelpers
   end
 
   def add_question(text)
-    click_link("Add question")
+    click_link(t("add_question"))
     fill_in("Text", with: text)
-    click_button("Create Question")
+    click_button(t("create_question"))
   end
 
-  def add_answer(text)
-    click_link("Add answer")
+  def add_answer(text, question_text:)
+    expect(page).to have_text(question_text)
+    click_link(t("add_answer"))
     fill_in("Text", with: text)
-    click_button("Create Answer")
+    click_button(t("create_answer"))
   end
 end

--- a/spec/system/answers_spec.rb
+++ b/spec/system/answers_spec.rb
@@ -3,13 +3,21 @@
 require "rails_helper"
 
 RSpec.describe "answers", type: :system do
-  it "allows creating an answer" do
-    create_and_sign_in_user
+  it "allows admins to create answers" do
+    user = create_and_sign_in_admin
+    create_question(user: user, text: "Where is Spain?")
 
-    add_question("Where is Spain?")
-    add_answer("In Europe")
+    expect(page).to have_link(I18n.t("add_answer"))
+    add_answer("In Europe", question_text: "Where is Spain?")
 
-    expect(page).to have_text("Where is Spain?")
     expect(page).to have_text("In Europe")
+  end
+
+  it "does not allow non-admins to create answers" do
+    user = create_and_sign_in_user
+    create_question(user: user, text: "What is electability?")
+
+    expect(page).to have_no_link(I18n.t("add_answer"))
+    expect(page).to have_text("What is electability?")
   end
 end

--- a/spec/system/questions_spec.rb
+++ b/spec/system/questions_spec.rb
@@ -3,12 +3,18 @@
 require "rails_helper"
 
 RSpec.describe "questions", type: :system do
-  it "allows us to create questions" do
-    user = User.create!(user_params)
-    sign_in_as(user)
+  it "allows admins to create questions" do
+    create_and_sign_in_admin
 
+    expect(page).to have_link(t("add_question"))
     add_question("Is climate change real?")
 
     expect(page).to have_text("Is climate change real?")
+  end
+
+  it "does not allow non-admins to create questions" do
+    create_and_sign_in_user
+
+    expect(page).to have_no_link(t("add_question"))
   end
 end


### PR DESCRIPTION
This makes use of the [`activerecord-pg_enum` gem][1] and
[`ActiveRecord::Enum` functionality][2]. I also added `I18n` keys for
button/link text to ensure that negative tests like `have_no_link` don't
become false positives down the road if we change the text.

[1]: https://github.com/alassek/activerecord-pg_enum/
[2]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html