### PR TITLE
Deps: lock down puma version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bootsnap", require: false
 gem "haml-rails"
 gem "pg"
 gem "pry-rails"
-gem "puma"
+gem "puma", "~> 5.6"
 gem "sass-rails"
 gem "sidekiq"
 gem "strong_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ DEPENDENCIES
   pg
   pry-byebug
   pry-rails
-  puma
+  puma (~> 5.6)
   rails (~> 7.0.0)
   rspec-rails
   rubocop


### PR DESCRIPTION
Puma >= 6 breaks Capybara, so we'll need to wait for the next release.
