### PR TITLE
Deps: pin Nokogiri to 1.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rails", "~> 7.0.0"
 gem "bcrypt"
 gem "bootsnap", require: false
 gem "haml-rails"
+gem "nokogiri", "~> 1.14.0.rc1" # for Ruby 3.2
 gem "pg"
 gem "pry-rails"
 gem "puma", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.0.rc1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -382,6 +382,7 @@ DEPENDENCIES
   haml-rails
   haml_lint
   listen
+  nokogiri (~> 1.14.0.rc1)
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
1.13 isn't compatible with Ruby 3.2.
